### PR TITLE
Simplify return value by using `pop()`

### DIFF
--- a/src/eventHandlers.js
+++ b/src/eventHandlers.js
@@ -13,9 +13,7 @@ const getSelectedFiles = (input) => {
   }
 
   if (input.value.indexOf(FAKE_PATH) !== -1) {
-    const splittedValue = input.value.split(FAKE_PATH_SEPARATOR)
-
-    return splittedValue[splittedValue.length - 1]
+    return input.value.split(FAKE_PATH_SEPARATOR).pop()
   }
 
   return input.value


### PR DESCRIPTION
Minor improvement.